### PR TITLE
This is a PR for v1.0 of JTAF.

### DIFF
--- a/Internal/processYang/processYang.go
+++ b/Internal/processYang/processYang.go
@@ -25,7 +25,6 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
-	s "strings"
 	"unicode/utf8"
 
 	"github.com/Juniper/junos-terraform/Internal/cfg"
@@ -139,12 +138,12 @@ func listFiles(filePath string) error {
 	// fmt.Println(string(out))
 
 	output := string(out[:])
-	lines := s.Split(output, "\n")
+	lines := strings.Split(output, "\n")
 	for _, line := range lines {
 		// TODO: Consider using regexp.Compile() for this.
 		matched, _ := regexp.Match(`.yang`, []byte(line))
 		if matched {
-			temp := s.Split(line, ".yang")
+			temp := strings.Split(line, ".yang")
 			yangFileList = append(yangFileList, temp[0])
 		}
 	}
@@ -336,7 +335,7 @@ func handleChoices(nodeChoice Node, strXpath string, strTab string) {
 func createFile(file string, fileType string) error {
 
 	if fileType == "text" || fileType == "both" {
-		var fileName string = s.Join([]string{file, "txt"}, ".")
+		var fileName string = strings.Join([]string{file, "txt"}, ".")
 		fPtr, err := os.Create(fileName)
 		if err != nil {
 			return err
@@ -351,7 +350,7 @@ func createFile(file string, fileType string) error {
 		fmt.Printf("Creating Xpath file: %s\n", fileName)
 	}
 	if fileType == "xml" || fileType == "both" {
-		var fileNameXML string = s.Join([]string{file, "xml"}, ".")
+		var fileNameXML string = strings.Join([]string{file, "xml"}, ".")
 		fPtr, err := os.Create(fileNameXML)
 		if err != nil {
 			return err

--- a/Internal/processYang/processYang.go
+++ b/Internal/processYang/processYang.go
@@ -169,6 +169,7 @@ func generateYinFile(filePath string) {
 		// pyang doesn't provide any output for creating Yin files
 		_, err := exec.Command("pyang", "-f", "yin", file+".yang", "-o", file+".yin", "-p", filePath).Output()
 		if err != nil {
+			fmt.Println("error processing file: ", file)
 			panic("pyang error: " + err.Error())
 		}
 

--- a/cmd/processProviders/main.go
+++ b/cmd/processProviders/main.go
@@ -25,6 +25,8 @@ import (
 	"github.com/Juniper/junos-terraform/Internal/processProviders"
 )
 
+const _ver = "0.1.0"
+
 // Syntactic helper to reduce repetition.
 func check(e error) {
 	if e != nil {
@@ -32,10 +34,26 @@ func check(e error) {
 	}
 }
 
+func PrintLogo() {
+	const jtafLogo = `
+                    ___ _____ ___  ______ 
+                   |_  |_   _/ _ \ |  ___|
+                     | | | |/ /_\ \| |_   
+                     | | | ||  _  ||  _|  
+                 /\__/ / | || | | || |    
+                 \____/  \_/\_| |_/\_| `
+
+	fmt.Println(jtafLogo)
+	fmt.Println("                           " + _ver)
+}
+
 func main() {
 
 	// The user can pass the configuration as part of config file or command line arguments.
 	jcfg := cfg.Config{}
+
+	// Version flag
+	verFlag := flag.Bool("v", false, "Check the version")
 
 	// Get the config location
 	flagConfig := flag.String("config", "", "Path to config file")
@@ -45,10 +63,13 @@ func main() {
 	flagXpath := flag.String("xpathPath", "", "Absolute path to file with xpath for Providers")
 	flagProvider := flag.String("providerDir", "", "Absolute path to directory to generate provider")
 
-	// Provide a line break for pretty reasons.
-	fmt.Println()
-
 	flag.Parse()
+
+	// Check the version.
+	if *verFlag {
+		fmt.Println("v", _ver)
+		return
+	}
 
 	// Get the config.
 	if *flagConfig != "" {
@@ -56,12 +77,17 @@ func main() {
 		if err != nil {
 			fmt.Println("Error retrieving configuration: ", err)
 		}
+
+		PrintLogo()
+
 		check(processProviders.CreateProviders(jcfg))
 	} else if *flagYang != "" || *flagXpath != "" || *flagProvider != "" {
 		// If config file path is not present then check for individual elements.
 		jcfg.XpathPath = *flagXpath
 		jcfg.ProviderDir = *flagProvider
 		jcfg.YangDir = *flagYang
+
+		PrintLogo()
 
 		check(processProviders.CreateProviders(jcfg))
 	} else {

--- a/cmd/processYang/main.go
+++ b/cmd/processYang/main.go
@@ -25,6 +25,8 @@ import (
 	"github.com/Juniper/junos-terraform/Internal/processYang"
 )
 
+const _ver = "0.1.0"
+
 // Syntactic helper to reduce repetition.
 func check(e error) {
 	if e != nil {
@@ -32,10 +34,26 @@ func check(e error) {
 	}
 }
 
+func PrintLogo() {
+	const jtafLogo = `
+                    ___ _____ ___  ______ 
+                   |_  |_   _/ _ \ |  ___|
+                     | | | |/ /_\ \| |_   
+                     | | | ||  _  ||  _|  
+                 /\__/ / | || | | || |    
+                 \____/  \_/\_| |_/\_| `
+
+	fmt.Println(jtafLogo)
+	fmt.Println("                           " + _ver)
+}
+
 func main() {
 
 	// The user can pass the configuration as part of config file or command line arguments.
 	jcfg := cfg.Config{}
+
+	// Version flag
+	verFlag := flag.Bool("v", false, "Check the version")
 
 	// Get the config location.
 	flagConfig := flag.String("config", "", "Path to config file")
@@ -44,10 +62,13 @@ func main() {
 	flagYang := flag.String("yangDir", "", "Absolute path to Yang files directory")
 	flagFileType := flag.String("fileType", "", "fileType for the xpath to be generated for Providers")
 
-	// Provide a line break for pretty reasons.
-	fmt.Println()
-
 	flag.Parse()
+
+	// Check the version.
+	if *verFlag {
+		fmt.Println("v", _ver)
+		return
+	}
 
 	// Get the config.
 	if *flagConfig != "" {
@@ -56,11 +77,15 @@ func main() {
 			fmt.Println("Error retrieving configuration: ", err)
 		}
 
+		PrintLogo()
+
 		check(processYang.CreateYinFileAndXpath(jcfg))
 	} else if *flagYang != "" || *flagFileType != "" {
 		// If config file path is not present then check for individual elements.
 		jcfg.FileType = *flagFileType
 		jcfg.YangDir = *flagYang
+
+		PrintLogo()
 
 		check(processYang.CreateYinFileAndXpath(jcfg))
 	} else {


### PR DESCRIPTION
- Pyang does not return output when creating Yin files, so it's been removed.
- Errors were being ignored such as malformed YANG model issues and now they're being acknowledged.
- Version numbers are now being returned from both `processYang` and `processProviders` binaries.
- There is a pretty header now included in `processYang` and `processProviders`.
- A summary statement exists for `processProviders` showing issues/success.
- Some code has been removed such as pretty printing whitespace.
- Tested with some simple .tf files against a vQFX.

Some output from processYang below:

```bash

                    ___ _____ ___  ______
                   |_  |_   _/ _ \ |  ___|
                     | | | |/ /_\ \| |_
                     | | | ||  _  ||  _|
                 /\__/ / | || | | || |
                 \____/  \_/\_| |_/\_|
                           0.1.0
----------------------------------------------------------------------------------------------------------
- Creating Yin files from Yang file directory: /Users/dgee/Documents/TF_Builds/nov_15_21_vqfx/yang_files -
----------------------------------------------------------------------------------------------------------
Yin file for junos-common-types@2019-01-01 is generated
Yin file for junos-qfx-conf-policy-options@2019-01-01 is generated
Yin file for junos-qfx-conf-protocols@2019-01-01 is generated
Yin file for junos-qfx-conf-root@2019-01-01 is generated
--------------------------------------------
- Creating _xpath files from the Yin files -
--------------------------------------------
Creating Xpath file: junos-common-types@2019-01-01_xpath.xml
Creating Xpath file: junos-qfx-conf-policy-options@2019-01-01_xpath.xml
Creating Xpath file: junos-qfx-conf-protocols@2019-01-01_xpath.xml
Creating Xpath file: junos-qfx-conf-root@2019-01-01_xpath.xml
```

Some output from processProviders below:

```bash
./processProviders -config /Users/dgee/Documents/TF_Builds/nov_15_21_vqfx/config.toml

                    ___ _____ ___  ______
                   |_  |_   _/ _ \ |  ___|
                     | | | |/ /_\ \| |_
                     | | | ||  _  ||  _|
                 /\__/ / | || | | || |
                 \____/  \_/\_| |_/\_|
                           0.1.0
------------------------------------------------------------
- Autogenerating Terraform Provider code from _xpath files -
------------------------------------------------------------
Terraform API resource_ProtocolsBgpGroupPeer__As created
Terraform API resource_ProtocolsBgpGroupNeighborExport created
Terraform API resource_ProtocolsBgpGroupFamilyInet6Unicast created
Terraform API resource_Policy__OptionsPolicy__StatementTermFromInterface created
Terraform API resource_Policy__OptionsPolicy__StatementTermThenAccept created
--------------------------------------------------------------------------------
Number of Xpaths processed:  5
Number of potential issues:  0
```