### PR TITLE
This set of commits covers JTAF 0.1.1

### DIFF
--- a/Internal/processYang/processYang.go
+++ b/Internal/processYang/processYang.go
@@ -166,9 +166,10 @@ func generateYinFile(filePath string) {
 	for _, file := range yangFileList {
 		// The search path is required for included models
 		// pyang doesn't provide any output for creating Yin files
-		_, err := exec.Command("pyang", "-f", "yin", file+".yang", "-o", file+".yin", "-p", filePath).Output()
+		output, err := exec.Command("pyang", "-f", "yin", file+".yang", "-o", file+".yin", "-p", filePath).Output()
 		if err != nil {
 			fmt.Println("error processing file: ", file)
+			fmt.Println("output from pyang: ", string(output))
 			panic("pyang error: " + err.Error())
 		}
 

--- a/cmd/processProviders/main.go
+++ b/cmd/processProviders/main.go
@@ -25,7 +25,7 @@ import (
 	"github.com/Juniper/junos-terraform/Internal/processProviders"
 )
 
-const _ver = "0.1.0"
+const _ver = "0.1.1"
 
 // Syntactic helper to reduce repetition.
 func check(e error) {

--- a/cmd/processYang/main.go
+++ b/cmd/processYang/main.go
@@ -25,7 +25,7 @@ import (
 	"github.com/Juniper/junos-terraform/Internal/processYang"
 )
 
-const _ver = "0.1.0"
+const _ver = "0.1.1"
 
 // Syntactic helper to reduce repetition.
 func check(e error) {


### PR DESCRIPTION
- pyang steps now provide a readable error message

- YANG list enums are now handled

To use those enums, in the Terraform HCL file, the key value must be " " with a single whitespace.
Junos will accept whitespace and it's harmonious to Terraform's HCL.

- Go-NETCONF bumped version to v0.1.5
There was a locking issue with errors. Mutex now releases on error and the connection can continue to be used.

- Error handling dumps data to a file instead of panicing.

1. We know when we should panic. Like not being able to open a connection is a catastrophic failure and thus, the program should immediately exit.
2. A normal error such as Junos refusing to commit because of a missing dependency during a set of deletions is considered a convergence characteristic and not an error, so do not panic.