### PR TITLE
Nil pointer empty xml

### DIFF
--- a/cmd/processProviders/main.go
+++ b/cmd/processProviders/main.go
@@ -25,7 +25,7 @@ import (
 	"github.com/Juniper/junos-terraform/Internal/processProviders"
 )
 
-const _ver = "0.1.3"
+const _ver = "0.1.4"
 
 // Syntactic helper to reduce repetition.
 func check(e error) {

--- a/cmd/processYang/main.go
+++ b/cmd/processYang/main.go
@@ -25,7 +25,7 @@ import (
 	"github.com/Juniper/junos-terraform/Internal/processYang"
 )
 
-const _ver = "0.1.3"
+const _ver = "0.1.4"
 
 // Syntactic helper to reduce repetition.
 func check(e error) {


### PR DESCRIPTION
Junos hands over empty XML elements when a feature is turned on, such as an 'orlonger' flag in a policy-map through choice-ident enums identified in YANG.

This change ensures that when an empty element is received, JTAF generated providers set the local state accordingly with a single " " whitespace, which indicates the feature is turned on.

Tested for all Terraform stages on vSRX platform.