### PR TITLE
1. There is an issue with how JTAF handles XPaths in comparison with …

### DIFF
--- a/Internal/processProviders/processProviders.go
+++ b/Internal/processProviders/processProviders.go
@@ -907,14 +907,14 @@ func handleContainer(nodes Node, strStructHierarchy string, schemaTab string) {
 		val_ += "__" + strconv.Itoa(int(id)) //string(id)
 	}
 
-	// WORKING ON ARAVIND ISSUE
+	// this logic removes embedded apply-macro and apply-groups that are superfluious and potentially breaking
 	if nodes.Key != "apply-macro" && nodes.Key != "apply-groups" {
 		strStruct += "\n" + schemaTab + "V_" + val_ + "\tstruct {\n" + schemaTab + "\tXMLName xml.Name `xml:\"" + nodes.Key + "\"`"
 		tab := schemaTab + "\t"
 		strStructHierarchy += ".V_" + val_
 		for _, n := range nodes.Nodes {
 			// If there is list or container, hierarchy needs to be added.
-			// If leaf or leaf-list then hierarchy doesn't need to ne there.
+			// If leaf or leaf-list then hierarchy doesn't need to be there.
 			// If uses, then grouping needs to be resolved.
 			if n.XMLName.Local == "container" || n.XMLName.Local == "list" {
 				handleContainer(n, strStructHierarchy, tab)

--- a/Samples/tf_module_template/module/vsrx_1/main.tf
+++ b/Samples/tf_module_template/module/vsrx_1/main.tf
@@ -29,6 +29,9 @@ resource "junos-vsrx_Policy__OptionsPolicy__StatementTermFromRoute__FilterAddres
     name = "DEF-IMPORT-FWTRUST-TABLE"
     name__1 = "t1"
     address = "10.0.0.0/17"
+    // orlonger below, is an enumerated type. The single whitespace turns it on.
+    // XPath for this type is: <xpath name="/policy-options/policy-statement/term/from/route-filter/address"/>
+    // Some enums require input, in which case use the key like any other and insert the data.
     orlonger = " "
 }
 

--- a/cmd/processProviders/main.go
+++ b/cmd/processProviders/main.go
@@ -25,7 +25,7 @@ import (
 	"github.com/Juniper/junos-terraform/Internal/processProviders"
 )
 
-const _ver = "0.1.4"
+const _ver = "0.1.5"
 
 // Syntactic helper to reduce repetition.
 func check(e error) {

--- a/cmd/processYang/main.go
+++ b/cmd/processYang/main.go
@@ -25,7 +25,7 @@ import (
 	"github.com/Juniper/junos-terraform/Internal/processYang"
 )
 
-const _ver = "0.1.4"
+const _ver = "0.1.5"
 
 // Syntactic helper to reduce repetition.
 func check(e error) {


### PR DESCRIPTION
…how the data structures should be verified. If an XPath is used to specify a single container, by default, any child leaf, leaf-lists or containers should not be included by default. A fix has been added to processProviders to account for this erroneous default inclusion.

2. XML omitempty tags have been added to fields (if they're not configured, don't use them etc).

3. Pointer semantics are used now for all `V_` data. This means the data structures are initialised with `nil`. If an empty element exists, then it won't be pushed to Junos. If Junos presents an empty element, then it will be read back and initialised, but empty.

4. Some of these issues are reasonably deep in the recursive nature of JTAF and so there are commented out debug statements. They will be handy for anyone else debugging JTAF.

5. Versions bumped to v0.1.5.

6. Ensured that apply-groups and apply-macro do not appear in any data structure. This will overcomplicate Terraform.