### PR TITLE
corrected version string in sample tf files

### DIFF
--- a/Samples/tf_module_template/module/main.tf
+++ b/Samples/tf_module_template/module/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     junos-vsrx = {
       source = "juniper/providers/junos-vsrx"
-      version = "20.32.0101"
+      version = "20.32.101"
     }
   }
 }

--- a/Samples/tf_module_template/module/vsrx_1/main.tf
+++ b/Samples/tf_module_template/module/vsrx_1/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     junos-vsrx = {
       source = "juniper/providers/junos-vsrx"
-      version = "20.32.0101"
+      version = "20.32.101"
     }
   }
 }


### PR DESCRIPTION
Numbers in version string can not have leading 0. Removed.

This fixes #32 