### PR TITLE
Migrate NETCONF junos_helper to provider. 

### DIFF
--- a/Internal/processProviders/go_config.go
+++ b/Internal/processProviders/go_config.go
@@ -1,4 +1,6 @@
-// Copyright (c) 2017-2021, Juniper Networks Inc. All rights reserved.
+package processProviders
+
+const providerConfigContent = `// Copyright (c) 2017-2021, Juniper Networks Inc. All rights reserved.
 //
 // License: Apache 2.0
 //
@@ -16,11 +18,11 @@
 
 package main
 
-import (
-	gonetconf "github.com/davedotdev/go-netconf/helpers/junos_helpers"
+import(
+	"terraform-provider-junos-%+v/netconf"
 )
 
-// Config is the configuration structure used to instantiate the GoNETCONF provider.
+// Config is the configuration structure used to instantiate the Netconf provider.
 type Config struct {
 	Host     string
 	Port     int
@@ -30,12 +32,12 @@ type Config struct {
 }
 
 // Client returns a new client for the provider to use
-func (c *Config) Client() (*gonetconf.GoNCClient, error) {
+func (c *Config) Client() (netconf.Client, error) {
 	return newClient(c)
 }
 
-func newClient(c *Config) (*gonetconf.GoNCClient, error) {
+func newClient(c *Config) (netconf.Client, error) {
 
-	client, err := gonetconf.NewClient(c.Username, c.Password, c.SSHKey, c.Host, c.Port)
+	client, err := netconf.NewClient(c.Username, c.Password, c.SSHKey, c.Host, c.Port)
 	return client, err
-}
+}`

--- a/Internal/processProviders/processProviders.go
+++ b/Internal/processProviders/processProviders.go
@@ -311,11 +311,12 @@ func CreateProviders(jcfg cfg.Config) error {
 			tpPath += "/"
 		}
 	}
+	fmt.Println(tpPath)
 	// Copy the go files from ../terraform_providers to the `providerDir` from the config file
 	PrintHeader("Copying files")
 	var fileCopyCount uint32
-	if err := copyDir(tpPath, jcfg.ProviderDir, ".go", jcfg.ProviderName, &fileCopyCount); err != nil {
-		panic(err)
+	if err := copyDir(tpPath, jcfg.ProviderDir, ".go", &fileCopyCount); err != nil {
+		return fmt.Errorf("failed to copy files from the %s direcotry: %w", tpPath, err)
 	}
 	fmt.Println("------------------------------------------------------------")
 	fmt.Println(fmt.Sprintf("- Copied a total of %d .go files from %s to %s -", fileCopyCount, filepath.Base(tpPath), filepath.Base(jcfg.ProviderDir)))
@@ -1199,7 +1200,7 @@ func Provider() *schema.Provider {
 `
 }
 
-func copyDir(src, dst, extension string, providerName string, fileCopyCount *uint32) error {
+func copyDir(src, dst, extension string, fileCopyCount *uint32) error {
 	return filepath.Walk(src, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
 			return err

--- a/terraform_providers/netconf/common.go
+++ b/terraform_providers/netconf/common.go
@@ -1,0 +1,14 @@
+package netconf
+
+type Client interface {
+	Close() error
+	ReadGroup(applygroup string) (string, error)
+	UpdateRawConfig(applygroup string, netconfcall string, commit bool) (string, error)
+	DeleteConfig(applygroup string) (string, error)
+	DeleteConfigNoCommit(applygroup string) (string, error)
+	SendCommit() error
+	MarshalGroup(id string, obj interface{}) error
+	SendTransaction(id string, obj interface{}, commit bool) error
+	SendRawConfig(netconfcall string, commit bool) (string, error)
+	ReadRawGroup(applygroup string) (string, error)
+}

--- a/terraform_providers/netconf/helper.go
+++ b/terraform_providers/netconf/helper.go
@@ -1,0 +1,436 @@
+package netconf
+
+import (
+	"bufio"
+	"encoding/xml"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"strings"
+	"sync"
+
+	driver "github.com/davedotdev/go-netconf/drivers/driver"
+	sshdriver "github.com/davedotdev/go-netconf/drivers/ssh"
+
+	"golang.org/x/crypto/ssh"
+)
+
+const groupStrXML = `<load-configuration action="merge" format="xml">
+%s
+</load-configuration>
+`
+
+const deleteStr = `<edit-config>
+	<target>
+		<candidate/>
+	</target>
+	<default-operation>none</default-operation> 
+	<config>
+		<configuration>
+			<groups operation="delete">
+				<name>%s</name>
+			</groups>
+			<apply-groups operation="delete">%s</apply-groups>
+		</configuration>
+	</config>
+</edit-config>`
+
+const commitStr = `<commit/>`
+
+const getGroupStr = `<get-configuration database="committed" format="text" >
+  <configuration>
+  <groups><name>%s</name></groups>
+  </configuration>
+</get-configuration>
+`
+
+const getGroupXMLStr = `<get-configuration>
+  <configuration>
+  <groups><name>%s</name></groups>
+  </configuration>
+</get-configuration>
+`
+
+// GoNCClient type for storing data and wrapping functions
+type GoNCClient struct {
+	Driver driver.Driver
+	Lock   sync.RWMutex
+}
+
+// Close is a functional thing to close the Driver
+func (g *GoNCClient) Close() error {
+	g.Driver = nil
+	return nil
+}
+
+// parseGroupData is a function that cleans up the returned data for generic config groups
+func parseGroupData(input string) (reply string, err error) {
+	var cfgSlice []string
+
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	scanner.Split(bufio.ScanWords)
+
+	for scanner.Scan() {
+		cfgSlice = append(cfgSlice, scanner.Text())
+	}
+
+	var cfgSlice2 []string
+
+	for _, v := range cfgSlice {
+		r := strings.NewReplacer("}\\n}\\n", "}", "\\n", "", "/*", "", "*/", "", "</configuration-text>", "")
+
+		d := r.Replace(v)
+
+		// fmt.Println(d)
+
+		cfgSlice2 = append(cfgSlice2, d)
+	}
+
+	// Figure out the offset. Each Junos version could give us different stuff, so let's look for the group name
+	begin := 0
+	end := 0
+
+	for k, v := range cfgSlice2 {
+		if v == "groups" {
+			begin = k + 4
+			break
+		}
+	}
+
+	// We don't want the very end slice due to config terminations we don't need.
+	end = len(cfgSlice2) - 3
+
+	// fmt.Printf("Begin = %v\nEnd = %v\n", begin, end)
+
+	reply = strings.Join(cfgSlice2[begin:end], " ")
+
+	return reply, nil
+}
+
+// ReadGroup is a helper function
+func (g *GoNCClient) ReadGroup(applygroup string) (string, error) {
+	g.Lock.Lock()
+	err := g.Driver.Dial()
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	getGroupString := fmt.Sprintf(getGroupStr, applygroup)
+
+	reply, err := g.Driver.SendRaw(getGroupString)
+	if err != nil {
+		return "", err
+	}
+
+	err = g.Driver.Close()
+
+	g.Lock.Unlock()
+
+	if err != nil {
+		return "", err
+	}
+
+	parsedGroupData, err := parseGroupData(reply.Data)
+	if err != nil {
+		return "", err
+	}
+
+	return parsedGroupData, nil
+}
+
+// UpdateRawConfig deletes group data and replaces it (for Update in TF)
+func (g *GoNCClient) UpdateRawConfig(applygroup string, netconfcall string, commit bool) (string, error) {
+
+	deleteString := fmt.Sprintf(deleteStr, applygroup, applygroup)
+
+	g.Lock.Lock()
+	err := g.Driver.Dial()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	_, err = g.Driver.SendRaw(deleteString)
+	if err != nil {
+		errInternal := g.Driver.Close()
+		g.Lock.Unlock()
+		return "", fmt.Errorf("driver error: %+v, driver close error: %+s", err, errInternal)
+	}
+
+	groupString := fmt.Sprintf(groupStrXML, netconfcall)
+
+	reply, err := g.Driver.SendRaw(groupString)
+	if err != nil {
+		errInternal := g.Driver.Close()
+		g.Lock.Unlock()
+		return "", fmt.Errorf("driver error: %+v, driver close error: %+s", err, errInternal)
+	}
+
+	if commit {
+		_, err = g.Driver.SendRaw(commitStr)
+		if err != nil {
+			errInternal := g.Driver.Close()
+			g.Lock.Unlock()
+			return "", fmt.Errorf("driver error: %+v, driver close error: %+s", err, errInternal)
+		}
+	}
+
+	err = g.Driver.Close()
+
+	if err != nil {
+		g.Lock.Unlock()
+		return "", fmt.Errorf("driver close error: %+s", err)
+	}
+
+	g.Lock.Unlock()
+
+	return reply.Data, nil
+}
+
+// DeleteConfig is a wrapper for driver.SendRaw()
+func (g *GoNCClient) DeleteConfig(applygroup string) (string, error) {
+
+	deleteString := fmt.Sprintf(deleteStr, applygroup, applygroup)
+
+	g.Lock.Lock()
+	err := g.Driver.Dial()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	reply, err := g.Driver.SendRaw(deleteString)
+	if err != nil {
+		errInternal := g.Driver.Close()
+		g.Lock.Unlock()
+		return "", fmt.Errorf("driver error: %+v, driver close error: %+s", err, errInternal)
+	}
+
+	_, err = g.Driver.SendRaw(commitStr)
+	if err != nil {
+		errInternal := g.Driver.Close()
+		g.Lock.Unlock()
+		return "", fmt.Errorf("driver error: %+v, driver close error: %+s", err, errInternal)
+	}
+
+	output := strings.Replace(reply.Data, "\n", "", -1)
+
+	err = g.Driver.Close()
+
+	g.Lock.Unlock()
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return output, nil
+}
+
+// DeleteConfigNoCommit is a wrapper for driver.SendRaw()
+// Does not provide mandatory commit unlike DeleteConfig()
+func (g *GoNCClient) DeleteConfigNoCommit(applygroup string) (string, error) {
+
+	deleteString := fmt.Sprintf(deleteStr, applygroup, applygroup)
+
+	g.Lock.Lock()
+	err := g.Driver.Dial()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	reply, err := g.Driver.SendRaw(deleteString)
+	if err != nil {
+		errInternal := g.Driver.Close()
+		g.Lock.Unlock()
+		return "", fmt.Errorf("driver error: %+v, driver close error: %+s", err, errInternal)
+	}
+
+	output := strings.Replace(reply.Data, "\n", "", -1)
+
+	err = g.Driver.Close()
+
+	if err != nil {
+		g.Lock.Unlock()
+		return "", fmt.Errorf("driver close error: %+s", err)
+	}
+
+	g.Lock.Unlock()
+
+	return output, nil
+}
+
+// SendCommit is a wrapper for driver.SendRaw()
+func (g *GoNCClient) SendCommit() error {
+	g.Lock.Lock()
+
+	err := g.Driver.Dial()
+
+	if err != nil {
+		g.Lock.Unlock()
+		return err
+	}
+
+	_, err = g.Driver.SendRaw(commitStr)
+	if err != nil {
+		g.Lock.Unlock()
+		return err
+	}
+
+	g.Lock.Unlock()
+	return nil
+}
+
+// MarshalGroup accepts a struct of type X and then marshals data onto it
+func (g *GoNCClient) MarshalGroup(id string, obj interface{}) error {
+
+	reply, err := g.ReadRawGroup(id)
+	if err != nil {
+		return err
+	}
+
+	err = xml.Unmarshal([]byte(reply), &obj)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// SendTransaction is a method that unnmarshals the XML, creates the transaction and passes in a commit
+func (g *GoNCClient) SendTransaction(id string, obj interface{}, commit bool) error {
+	jconfig, err := xml.Marshal(obj)
+
+	if err != nil {
+		return err
+	}
+
+	// UpdateRawConfig deletes old group by, re-creates it then commits.
+	// As far as Junos cares, it's an edit.
+	if id != "" {
+		_, err = g.UpdateRawConfig(id, string(jconfig), commit)
+	} else {
+		_, err = g.SendRawConfig(string(jconfig), commit)
+	}
+
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// SendRawConfig is a wrapper for driver.SendRaw()
+func (g *GoNCClient) SendRawConfig(netconfcall string, commit bool) (string, error) {
+
+	groupString := fmt.Sprintf(groupStrXML, netconfcall)
+
+	g.Lock.Lock()
+
+	err := g.Driver.Dial()
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	reply, err := g.Driver.SendRaw(groupString)
+	if err != nil {
+		errInternal := g.Driver.Close()
+		g.Lock.Unlock()
+		return "", fmt.Errorf("driver error: %+v, driver close error: %+s", err, errInternal)
+	}
+
+	if commit {
+		_, err = g.Driver.SendRaw(commitStr)
+		if err != nil {
+			errInternal := g.Driver.Close()
+			g.Lock.Unlock()
+			return "", fmt.Errorf("driver error: %+v, driver close error: %+s", err, errInternal)
+		}
+	}
+
+	err = g.Driver.Close()
+
+	if err != nil {
+		g.Lock.Unlock()
+		return "", err
+	}
+
+	g.Lock.Unlock()
+
+	return reply.Data, nil
+}
+
+// ReadRawGroup is a helper function
+func (g *GoNCClient) ReadRawGroup(applygroup string) (string, error) {
+	g.Lock.Lock()
+	err := g.Driver.Dial()
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	getGroupXMLString := fmt.Sprintf(getGroupXMLStr, applygroup)
+
+	reply, err := g.Driver.SendRaw(getGroupXMLString)
+	if err != nil {
+		errInternal := g.Driver.Close()
+		g.Lock.Unlock()
+		return "", fmt.Errorf("driver error: %+v, driver close error: %+s", err, errInternal)
+	}
+
+	err = g.Driver.Close()
+
+	g.Lock.Unlock()
+
+	if err != nil {
+		return "", err
+	}
+
+	return reply.Data, nil
+}
+
+func publicKeyFile(file string) ssh.AuthMethod {
+	buffer, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil
+	}
+
+	key, err := ssh.ParsePrivateKey(buffer)
+	if err != nil {
+		return nil
+	}
+	return ssh.PublicKeys(key)
+}
+
+// NewClient returns gonetconf new client driver
+func NewClient(username string, password string, sshkey string, address string, port int) (Client, error) {
+
+	// Dummy interface var ready for loading from inputs
+	var nconf driver.Driver
+
+	d := driver.New(sshdriver.New())
+
+	nc := d.(*sshdriver.DriverSSH)
+
+	nc.Host = address
+	nc.Port = port
+
+	// SSH keys takes priority over password based
+	if sshkey != "" {
+		nc.SSHConfig = &ssh.ClientConfig{
+			User: username,
+			Auth: []ssh.AuthMethod{
+				publicKeyFile(sshkey),
+			},
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		}
+	} else {
+		// Sort yourself out with SSH. Easiest to do that here.
+		nc.SSHConfig = &ssh.ClientConfig{
+			User:            username,
+			Auth:            []ssh.AuthMethod{ssh.Password(password)},
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		}
+	}
+
+	nconf = nc
+
+	return &GoNCClient{Driver: nconf}, nil
+}


### PR DESCRIPTION
The purpose of this pull request is to migrate the `junos_helpers` functionality from `go-netconf` to this project, it is still using the `go-netconf` library but instead of depending upon the `junos_helpers` from the library we simply implement it within this repo. 

This should allow for easier changes to the NETCONF calls that are being used from this provider while preventing any unwanted changes to the underlying libraries helper such as adding in a bulk/batch mode etc.

To accomplish this I have made the following notable changes. 

* The `terraform_providers` directory now contains a `netconf` directory, this is essentially a like for like copy of the `junos_helpers` file from `go-netconf` with the exception that we now return an interface structure, the reason for this is so that we can add or remove more helper files as long as it satisfies the interface requirements. 

* The `config.go` library has been moved from the `terraform_providers` directory and is now a generated resource, the purpose for this is so that we can correctly import and use any subdirectories within the `terraform_providers` directory eg: the `netconf` directory

*  The function which copies files from the `terraform_providers`  has been updated to also copy files within subdirectories while maintaining the proper pathing, I also added in some logging to the terminal around the files that have been copied over.

* when generating the `provider.go` file it now has the pathing to the local `netconf` library added in.

 