### PR TITLE
Error handling for process yang functionality

### DIFF
--- a/cmd/processYang/checkVenv.py
+++ b/cmd/processYang/checkVenv.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+"""
+// Copyright (c) 2017-2021, Juniper Networks Inc. All rights reserved.
+//
+// License: Apache 2.0
+//
+// THIS SOFTWARE IS PROVIDED BY Juniper Networks, Inc. ''AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL Juniper Networks, Inc. BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+"""
+import sys
+
+def getBasePrefix():
+    return getattr(sys, "base_prefix", None) or getattr(sys, "real_prefix", 
+                                                        None) or sys.prefix
+if __name__ == "__main__":
+    if getBasePrefix() != sys.prefix:
+        print('true')
+    else:
+        print('false')

--- a/cmd/processYang/main.go
+++ b/cmd/processYang/main.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/exec"
 
 	"github.com/Juniper/junos-terraform/Internal/cfg"
 	"github.com/Juniper/junos-terraform/Internal/processYang"
@@ -31,6 +32,35 @@ const _ver = "0.1.5"
 func check(e error) {
 	if e != nil {
 		panic(e)
+	}
+}
+
+// Check if running from venv
+func check_venv_exists() {
+	app	:= "python3"
+	script	:= "checkVenv.py"
+	cmd := exec.Command(app, script)
+	stdout, err := cmd.Output()
+
+	if err != nil {
+		fmt.Println(err.Error())
+		panic(err)
+	}
+	if string(stdout) == "false\n" {
+		fmt.Println("ERROR: Please run this in a python3 virtual environment.\n")
+		os.Exit(1)
+	}
+}
+
+func check_pyang_installed() {
+	app := "pyang"
+	ver := "-v"
+	cmd := exec.Command(app, ver)
+	_, err := cmd.Output()
+
+	if err != nil {
+		fmt.Println("ERROR: Please install pyang in the virtual environment.\n")
+		os.Exit(1)
 	}
 }
 
@@ -79,6 +109,8 @@ func main() {
 
 		PrintLogo()
 
+		check_venv_exists()
+		check_pyang_installed()
 		check(processYang.CreateYinFileAndXpath(jcfg))
 	} else if *flagYang != "" || *flagFileType != "" {
 		// If config file path is not present then check for individual elements.
@@ -87,6 +119,8 @@ func main() {
 
 		PrintLogo()
 
+		check_venv_exists()
+		check_pyang_installed()
 		check(processYang.CreateYinFileAndXpath(jcfg))
 	} else {
 		fmt.Println("One or more mandatory inputs are missing, exiting...")


### PR DESCRIPTION
This fixes #34 

Added check for process yang being executed from venv. If not, then following error is printed for the user:
ERROR: Please run this in a python3 virtual environment.

Added check for installation of pyang in venv. If not, then following error is printed for the user:
ERROR: Please install pyang in the virtual environment.