### PR TITLE
Syntax corrected for go_mod file

### DIFF
--- a/Internal/processProviders/go_mod.go
+++ b/Internal/processProviders/go_mod.go
@@ -9,4 +9,4 @@ require (
         github.com/davedotdev/go-netconf v0.1.5
 	github.com/hashicorp/terraform-plugin-log v0.4.0
         github.com/hashicorp/terraform-plugin-sdk/v2 v2.16
-)
+)`


### PR DESCRIPTION
Fixes #38 

String was not enclosed in go_mod file. It is now corrected.