### PR TITLE
Support for combining multiple xml files

### DIFF
--- a/junosterraform/jtaf-provider
+++ b/junosterraform/jtaf-provider
@@ -238,12 +238,13 @@ def main():
     # other arguments
     parser = argparse.ArgumentParser(exit_on_error=True)
     parser.add_argument('-j', '--json-schema', required=True, help='specify the json schema file')
-    parser.add_argument('-x', '--xml-config', required=True, nargs='+', help='specify one or more XML config files to combine')
+    parser.add_argument('-x', '--xml-config', required=True, action='append', nargs="+", help='specify one or more XML config files to combine')
     parser.add_argument('-t', '--type', required=True, help='device type (i.e. vsrx, mx960, ex4200, etc)')
     args = parser.parse_args()
 
     # Merge XML files if multiple are provided 
-    xml_config = args.xml_config[0] if len(args.xml_config) == 1 else load_and_merge_xmls(args.xml_config)
+    xml_files = [file for group in args.xml_config for file in group]
+    xml_config = xml_files[0] if len(xml_files) == 1 else load_and_merge_xmls(xml_files)
 
     # Step 1: Filter the schema using the config
     resources = filter_json_using_xml(args.json_schema, xml_config)

--- a/junosterraform/jtaf-provider
+++ b/junosterraform/jtaf-provider
@@ -224,13 +224,13 @@ def main():
     # other arguments
     parser = argparse.ArgumentParser(exit_on_error=True)
     parser.add_argument('-j', '--json-schema', required=True, help='specify the json schema file')
-    parser.add_argument('-x', '--xml-config', required=True, action='append', help='specify one or more XML config files to combine')
+    parser.add_argument('-x', '--xml-config', required=True, action='append', nargs="+", help='specify one or more XML config files to combine')
     parser.add_argument('-t', '--type', required=True, help='device type (i.e. vsrx, mx960, ex4200, etc)')
     args = parser.parse_args()
 
     # Merge XML files if multiple are provided 
     xml_files = [file for group in args.xml_config for file in group]
-    xml_config = xml_files[0] if len(xml_files) == 1 else load_and_merge_xmls(args.xml_config)
+    xml_config = xml_files[0] if len(xml_files) == 1 else load_and_merge_xmls(xml_files)
 
     # Step 1: Filter the schema using the config
     resources = filter_json_using_xml(args.json_schema, xml_config)

--- a/junosterraform/jtaf-provider
+++ b/junosterraform/jtaf-provider
@@ -224,12 +224,13 @@ def main():
     # other arguments
     parser = argparse.ArgumentParser(exit_on_error=True)
     parser.add_argument('-j', '--json-schema', required=True, help='specify the json schema file')
-    parser.add_argument('-x', '--xml-config', required=True, nargs='+', help='specify one or more XML config files to combine')
+    parser.add_argument('-x', '--xml-config', required=True, action='append', help='specify one or more XML config files to combine')
     parser.add_argument('-t', '--type', required=True, help='device type (i.e. vsrx, mx960, ex4200, etc)')
     args = parser.parse_args()
 
     # Merge XML files if multiple are provided 
-    xml_config = args.xml_config[0] if len(args.xml_config) == 1 else load_and_merge_xmls(args.xml_config)
+    xml_files = [file for group in args.xml_config for file in group]
+    xml_config = xml_files[0] if len(xml_files) == 1 else load_and_merge_xmls(args.xml_config)
 
     # Step 1: Filter the schema using the config
     resources = filter_json_using_xml(args.json_schema, xml_config)

--- a/junosterraform/jtaf-provider
+++ b/junosterraform/jtaf-provider
@@ -169,11 +169,15 @@ def filter_json_using_xml(schema, xml):
     else:
         with open(schema) as f:
             schema = json.load(f)
-    with open(xml) as f:
-        xml_text = f.read()
 
-    # Parse XML under temporary root
-    root = ElementTree.fromstring(f"<root>{xml_text}</root>")
+    # Check if xml is a single file or merged xml element 
+    if isinstance(xml, str):
+        with open(xml) as f:
+            xml_text = f.read()
+        # Parse XML under temporary root
+        root = ElementTree.fromstring(f"<root>{xml_text}</root>")
+    else:
+        root = xml
 
     # Try to find the <configuration> node under <rpc-reply>
     config_node = root.find(".//configuration")
@@ -199,17 +203,36 @@ def render_template_and_write(input_template: str, output_file: str, context: di
         f.write(rendered)
     print(f"Updated {description}")
 
+def load_and_merge_xmls(xml_file_list):
+    merged_config = ElementTree.Element("configuration")
+
+    # Parse and find <configuration> in each file
+    for path in xml_file_list:
+        with open(path) as f:
+            raw = f.read()
+        root = ElementTree.fromstring(f"<root>{raw}</root>")
+        config = root.find(".//configuration")
+        if config is None:
+            raise ValueError(f"No <configuration> found in {path}")
+        for child in config:
+                merged_config.append(child)
+
+    return merged_config
+
 # Main Method
 def main():
     # other arguments
     parser = argparse.ArgumentParser(exit_on_error=True)
     parser.add_argument('-j', '--json-schema', required=True, help='specify the json schema file')
-    parser.add_argument('-x', '--xml-config', required=True, help='specify the xml config file')
+    parser.add_argument('-x', '--xml-config', required=True, nargs='+', help='specify one or more XML config files to combine')
     parser.add_argument('-t', '--type', required=True, help='device type (i.e. vsrx, mx960, ex4200, etc)')
     args = parser.parse_args()
 
+    # Merge XML files if multiple are provided 
+    xml_config = args.xml_config[0] if len(args.xml_config) == 1 else load_and_merge_xmls(args.xml_config)
+
     # Step 1: Filter the schema using the config
-    resources = filter_json_using_xml(args.json_schema, args.xml_config)
+    resources = filter_json_using_xml(args.json_schema, xml_config)
 
     # Step 2: Render the template into Go code
 

--- a/junosterraform/jtaf-provider
+++ b/junosterraform/jtaf-provider
@@ -116,6 +116,22 @@ def check_children(paths, elem, node_parent, current_path):
     else:
         return True
     return False
+
+def remove_tags_by_name(root, tag_names):
+    # Recursively remove all nodes with matching tag names 
+    for tag in tag_names:
+        for elem in root.findall(f".//{tag}"):
+            parent = find_parent(root, elem)
+            if parent is not None:
+                parent.remove(elem)
+
+def find_parent(root, child):
+    # Find parent of a given element 
+    for parent in root.iter():
+        for elem in parent:
+            if elem is child:
+                return parent
+    return None
  
 def walk_schema(paths, node, parent = []):
     result = None
@@ -186,9 +202,7 @@ def filter_json_using_xml(schema, xml):
         root = config_node
 
     # find and remove any version node
-    version_node = root.find("./version")
-    if version_node is not None:
-        root.remove(version_node)
+    remove_tags_by_name(root, ["version", "versions", "model"])
 
     # find the unique paths
     paths = unique_xpaths(get_xpaths(root))
@@ -224,13 +238,12 @@ def main():
     # other arguments
     parser = argparse.ArgumentParser(exit_on_error=True)
     parser.add_argument('-j', '--json-schema', required=True, help='specify the json schema file')
-    parser.add_argument('-x', '--xml-config', required=True, action='append', nargs="+", help='specify one or more XML config files to combine')
+    parser.add_argument('-x', '--xml-config', required=True, nargs='+', help='specify one or more XML config files to combine')
     parser.add_argument('-t', '--type', required=True, help='device type (i.e. vsrx, mx960, ex4200, etc)')
     args = parser.parse_args()
 
     # Merge XML files if multiple are provided 
-    xml_files = [file for group in args.xml_config for file in group]
-    xml_config = xml_files[0] if len(xml_files) == 1 else load_and_merge_xmls(xml_files)
+    xml_config = args.xml_config[0] if len(args.xml_config) == 1 else load_and_merge_xmls(args.xml_config)
 
     # Step 1: Filter the schema using the config
     resources = filter_json_using_xml(args.json_schema, xml_config)


### PR DESCRIPTION
**Issue #72:** Change jtaf-provider to accept multiple xml files

**Note:**
Implemented single flag with multiple values:
`jtaf-provider -t qfx -j junos.json -x examples/evpn-vxlan/dc1/dc1-leaf1.xml examples/evpn-vxlan/dc1/dc1-spine1.xml`
Instead of repeatable flags:
`jtaf-provider -t qfx -j junos.json -x examples/evpn-vxlan/dc1/dc1-leaf1.xml -x examples/evpn-vxlan/dc1/dc1-spine1.xml`

Is that alright?