### PR TITLE
Add support for specifying multiple XML files for yang2go

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ jtaf-xml2tf -x <device-xml-config> -t <device-type> -n <deivce-host-name>
 
 Example: 
 ```
-jtaf-xml2tf -x config.xml -t vqfx -n dc2-spine1
+jtaf-xml2tf -x examples/evpn-vxlan-dc/dc2/dc2-spine1.xml -t vqfx -n dc2-spine1
 ```
 
 Using the output from the terminal, which represents a template for the HCL .tf file, we can create our testing environment and fill in the template with the necessary device information.
@@ -145,6 +145,6 @@ You should know have a file structure which looks similar to:
 Once the `.terraform.rc` file is set up, and the `main.tf` test file contains access to the provider, information regarding the desired devices to push the configuration to, and the desired config in `HCL` format, we are now ready to use the provider.
 
 ```
-terrafrom plan
+terraform plan
 terraform apply -auto-approve
 ```

--- a/junosterraform/jtaf-yang2go
+++ b/junosterraform/jtaf-yang2go
@@ -11,12 +11,13 @@ package_dir = os.path.dirname(pkg_resources.resource_filename('jtaf_pyang_plugin
 
 parser = argparse.ArgumentParser(description='Convert YANG to Go')
 parser.add_argument('-p', type=str, help='Path to YANG files, if there are multiple files, use double quotes to wrap the path', required=True, nargs='*', action='extend')
-parser.add_argument('-x', type=str, help='Path of Junos OS XML file', required=True)
+parser.add_argument('-x', type=str, action='append', nargs="+", help='Path of one or more Junos OS XML files')
 parser.add_argument('-t', type=str, help='Device type', required=True)
 
 args = parser.parse_args()
 
-xml_file = args.x
+# Combine all XML file names into one string
+xml_files = [file for group in args.x for file in group]
 device_type = args.t
 
 # Separate search paths and yang files (expand globs)
@@ -47,7 +48,7 @@ if p1.returncode == 0 and pyang_out:
     p2 = subprocess.Popen([
         'jtaf-provider',
         '-j', '-',
-        '-x', xml_file,
+        '-x', *xml_files,
         '-t', device_type
     ], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     output, error = p2.communicate(input=pyang_out)


### PR DESCRIPTION
Also, fixed a typo in the README (terrafrom --> terraform) and changed generic name in jtaf-xml2tf example to match previous examples (config.xml --> examples/evpn-vxlan-dc/dc2/dc2-spine1.xml). 