### PR TITLE
Adding support for multiple xml files for xml2tf

### DIFF
--- a/junosterraform/jtaf-xml2tf
+++ b/junosterraform/jtaf-xml2tf
@@ -246,12 +246,13 @@ def parse_xml_to_hcl(xml_file, device_type, hostname, type_lookup):
 
 def main():
     parser = argparse.ArgumentParser(exit_on_error=True)
-    parser.add_argument('-x', '--xml-config', required=True, help='specify the xml config file')
+    parser.add_argument('-x', '--xml-config', required=True, action='append', nargs="+", help='specify one or more XML config files')
     parser.add_argument('-t', '--type', required=True, help='device type (i.e. vsrx, mx960, ex4200, etc)')
     parser.add_argument('-n', '--hostname', required=True, help='device hostname (i.e. dc2-spine1, dc2-spine2, etc)')
+    parser.add_argument('-o', '--output', action='store_true', help='if provided, write out terraform config(s) to file')
     args = parser.parse_args()
 
-    xml_file = args.xml_config
+    xml_files = [file for group in args.xml_config for file in group]
     device_type = args.type
     hostname = args.hostname
 
@@ -270,10 +271,19 @@ def main():
     type_lookup = build_type_map(config_node)
     
     # Traverse xml to create HCL resources
-    hcl_output = parse_xml_to_hcl(xml_file, device_type, hostname, type_lookup)
-    if hcl_output:
-        print("\nGenerated Terraform Configuration:\n")
-        print(hcl_output)   
+    for xml_file in xml_files:
+        file_hostname = xml_file.split("/")[-1].split(".")[0]
+        hcl_output = parse_xml_to_hcl(xml_file, device_type, file_hostname, type_lookup)
+        if hcl_output:
+            if args.output:
+                filename = f"terraform-provider-junos-{device_type}/testbed/{file_hostname}.tf"
+                os.makedirs(os.path.dirname(filename), exist_ok=True)
+                with open(filename, "w") as f:
+                    f.write(hcl_output)
+                print(f"Wrote output to {filename}")
+            else:
+                print("\nGenerated Terraform Configuration:\n")
+                print(hcl_output)  
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Also, added optional -o flag to write out tf files for testing purposes.

Right now, the hostname is being extracted from the xml path. Would you rather have users pass in multiple hostnames with -n? Should the -n option not be necessary if multiple xml paths are provided?