### PR TITLE
Fixing .tf generation to generate only valid arguments with resource blocks

### DIFF
--- a/junosterraform/jtaf-xml2tf
+++ b/junosterraform/jtaf-xml2tf
@@ -75,8 +75,8 @@ def parse_element(element, explicit_empty_tags, type_lookup, parent_path=""):
         full_xml_path = path  # non-normalized, user-facing path
         if full_xml_path not in missing_xpaths:
             missing_xpaths.add(full_xml_path)
-            print(f"\t -- [WARN] Unknown XML path not in schema: '{full_xml_path}'\n\t\tAdd this path to an augmented YANG file and re-run yang2go to regenerate the JSON schema.\n\t\tTerraform cannot track this path until it is added.\n", file=sys.stderr)
-
+            # print(f"\t -- [WARN] Unknown XML path not in schema: '{full_xml_path}'\n\t\tAdd this path to an augmented YANG file and re-run yang2go to regenerate the JSON schema.\n\t\tTerraform cannot track this path until it is added.\n", file=sys.stderr)
+            print(f"\t-- [WARN] XML config '{full_xml_path}' not defined in YANG.\n\t\tTo enable configuration of this element, add it to a YANG augment file.\n\t\t - Regenerate the provider using jtaf-yang2go and including this file using the -p option in addition to the existing YANG files.\n", file=sys.stderr)
     # Check if this element should be a leaf-list
     type_info = type_lookup.get(normalized_path, {})
     is_leaf_list = type_info.get("type") == "leaf-list"


### PR DESCRIPTION
Before jtaf-xml2tf was taking the config (.xml) directly and turning it into .tf resource files. This would cause backward incompatibility for those trying to use an input config for version 25.4 to push config to a device that is version 23..2. This fix will now ensure that before adding an argument to the resource in the .tf files, it is considered valid by checking if it exists in the trimmed_schema as well (schema would be built using 23.2). Fix ensures that config that is not valid is not pushed to the device even if the user input config contains it.