### PR TITLE
FIX: Changing jtaf-xml2tf back to remove paths from .tf which are not found in the trimmed schema. 

### DIFF
--- a/examples/terraform_files/dc1-borderleaf1.tf
+++ b/examples/terraform_files/dc1-borderleaf1.tf
@@ -39,19 +39,6 @@ resource "terraform-provider-junos-vqfx-evpn-vxlan" "dc1-borderleaf1-base-config
                 {
                   grpc = [
                     {
-                      undocumented = [
-                        {
-                          clear_text = [
-                            {
-                              address = "0.0.0.0"
-                              port = 32767
-                            }
-                          ]
-                        },
-                        {
-                          skip_authentication = ""
-                        }
-                      ]
                       max_connections = 30
                     }
                   ]

--- a/examples/terraform_files/dc1-borderleaf2.tf
+++ b/examples/terraform_files/dc1-borderleaf2.tf
@@ -39,19 +39,6 @@ resource "terraform-provider-junos-vqfx-evpn-vxlan" "dc1-borderleaf2-base-config
                 {
                   grpc = [
                     {
-                      undocumented = [
-                        {
-                          clear_text = [
-                            {
-                              address = "0.0.0.0"
-                              port = 32767
-                            }
-                          ]
-                        },
-                        {
-                          skip_authentication = ""
-                        }
-                      ]
                       max_connections = 30
                     }
                   ]

--- a/examples/terraform_files/dc1-firewall1.tf
+++ b/examples/terraform_files/dc1-firewall1.tf
@@ -39,19 +39,6 @@ resource "terraform-provider-junos-vsrx-evpn-vxlan" "dc1-firewall1-base-config" 
                 {
                   grpc = [
                     {
-                      undocumented = [
-                        {
-                          clear_text = [
-                            {
-                              address = "0.0.0.0"
-                              port = 32767
-                            }
-                          ]
-                        },
-                        {
-                          skip_authentication = ""
-                        }
-                      ]
                       max_connections = 30
                     }
                   ]
@@ -194,11 +181,6 @@ resource "terraform-provider-junos-vsrx-evpn-vxlan" "dc1-firewall1-base-config" 
                       attack_threshold = 200
                       source_threshold = 1024
                       destination_threshold = 2048
-                      undocumented = [
-                        {
-                          queue_size = 2000
-                        }
-                      ]
                       timeout = 20
                     }
                   ]

--- a/examples/terraform_files/dc1-firewall2.tf
+++ b/examples/terraform_files/dc1-firewall2.tf
@@ -39,19 +39,6 @@ resource "terraform-provider-junos-vsrx-evpn-vxlan" "dc1-firewall2-base-config" 
                 {
                   grpc = [
                     {
-                      undocumented = [
-                        {
-                          clear_text = [
-                            {
-                              address = "0.0.0.0"
-                              port = 32767
-                            }
-                          ]
-                        },
-                        {
-                          skip_authentication = ""
-                        }
-                      ]
                       max_connections = 30
                     }
                   ]
@@ -194,11 +181,6 @@ resource "terraform-provider-junos-vsrx-evpn-vxlan" "dc1-firewall2-base-config" 
                       attack_threshold = 200
                       source_threshold = 1024
                       destination_threshold = 2048
-                      undocumented = [
-                        {
-                          queue_size = 2000
-                        }
-                      ]
                       timeout = 20
                     }
                   ]

--- a/examples/terraform_files/dc1-leaf1.tf
+++ b/examples/terraform_files/dc1-leaf1.tf
@@ -39,19 +39,6 @@ resource "terraform-provider-junos-vqfx-evpn-vxlan" "dc1-leaf1-base-config" {
                 {
                   grpc = [
                     {
-                      undocumented = [
-                        {
-                          clear_text = [
-                            {
-                              address = "0.0.0.0"
-                              port = 32767
-                            }
-                          ]
-                        },
-                        {
-                          skip_authentication = ""
-                        }
-                      ]
                       max_connections = 30
                     }
                   ]

--- a/examples/terraform_files/dc1-leaf2.tf
+++ b/examples/terraform_files/dc1-leaf2.tf
@@ -39,19 +39,6 @@ resource "terraform-provider-junos-vqfx-evpn-vxlan" "dc1-leaf2-base-config" {
                 {
                   grpc = [
                     {
-                      undocumented = [
-                        {
-                          clear_text = [
-                            {
-                              address = "0.0.0.0"
-                              port = 32767
-                            }
-                          ]
-                        },
-                        {
-                          skip_authentication = ""
-                        }
-                      ]
                       max_connections = 30
                     }
                   ]

--- a/examples/terraform_files/dc1-leaf3.tf
+++ b/examples/terraform_files/dc1-leaf3.tf
@@ -39,19 +39,6 @@ resource "terraform-provider-junos-vqfx-evpn-vxlan" "dc1-leaf3-base-config" {
                 {
                   grpc = [
                     {
-                      undocumented = [
-                        {
-                          clear_text = [
-                            {
-                              address = "0.0.0.0"
-                              port = 32767
-                            }
-                          ]
-                        },
-                        {
-                          skip_authentication = ""
-                        }
-                      ]
                       max_connections = 30
                     }
                   ]

--- a/examples/terraform_files/dc1-spine1.tf
+++ b/examples/terraform_files/dc1-spine1.tf
@@ -39,19 +39,6 @@ resource "terraform-provider-junos-vqfx-evpn-vxlan" "dc1-spine1-base-config" {
                 {
                   grpc = [
                     {
-                      undocumented = [
-                        {
-                          clear_text = [
-                            {
-                              address = "0.0.0.0"
-                              port = 32767
-                            }
-                          ]
-                        },
-                        {
-                          skip_authentication = ""
-                        }
-                      ]
                       max_connections = 30
                     }
                   ]

--- a/examples/terraform_files/dc1-spine2.tf
+++ b/examples/terraform_files/dc1-spine2.tf
@@ -39,19 +39,6 @@ resource "terraform-provider-junos-vqfx-evpn-vxlan" "dc1-spine2-base-config" {
                 {
                   grpc = [
                     {
-                      undocumented = [
-                        {
-                          clear_text = [
-                            {
-                              address = "0.0.0.0"
-                              port = 32767
-                            }
-                          ]
-                        },
-                        {
-                          skip_authentication = ""
-                        }
-                      ]
                       max_connections = 30
                     }
                   ]

--- a/examples/terraform_files/dc2-firewall1.tf
+++ b/examples/terraform_files/dc2-firewall1.tf
@@ -39,19 +39,6 @@ resource "terraform-provider-junos-vsrx-evpn-vxlan" "dc2-firewall1-base-config" 
                 {
                   grpc = [
                     {
-                      undocumented = [
-                        {
-                          clear_text = [
-                            {
-                              address = "0.0.0.0"
-                              port = 32767
-                            }
-                          ]
-                        },
-                        {
-                          skip_authentication = ""
-                        }
-                      ]
                       max_connections = 30
                     }
                   ]
@@ -194,11 +181,6 @@ resource "terraform-provider-junos-vsrx-evpn-vxlan" "dc2-firewall1-base-config" 
                       attack_threshold = 200
                       source_threshold = 1024
                       destination_threshold = 2048
-                      undocumented = [
-                        {
-                          queue_size = 2000
-                        }
-                      ]
                       timeout = 20
                     }
                   ]

--- a/examples/terraform_files/dc2-firewall2.tf
+++ b/examples/terraform_files/dc2-firewall2.tf
@@ -39,19 +39,6 @@ resource "terraform-provider-junos-vsrx-evpn-vxlan" "dc2-firewall2-base-config" 
                 {
                   grpc = [
                     {
-                      undocumented = [
-                        {
-                          clear_text = [
-                            {
-                              address = "0.0.0.0"
-                              port = 32767
-                            }
-                          ]
-                        },
-                        {
-                          skip_authentication = ""
-                        }
-                      ]
                       max_connections = 30
                     }
                   ]
@@ -194,11 +181,6 @@ resource "terraform-provider-junos-vsrx-evpn-vxlan" "dc2-firewall2-base-config" 
                       attack_threshold = 200
                       source_threshold = 1024
                       destination_threshold = 2048
-                      undocumented = [
-                        {
-                          queue_size = 2000
-                        }
-                      ]
                       timeout = 20
                     }
                   ]

--- a/examples/terraform_files/dc2-spine1.tf
+++ b/examples/terraform_files/dc2-spine1.tf
@@ -39,19 +39,6 @@ resource "terraform-provider-junos-vqfx-evpn-vxlan" "dc2-spine1-base-config" {
                 {
                   grpc = [
                     {
-                      undocumented = [
-                        {
-                          clear_text = [
-                            {
-                              address = "0.0.0.0"
-                              port = 32767
-                            }
-                          ]
-                        },
-                        {
-                          skip_authentication = ""
-                        }
-                      ]
                       max_connections = 30
                     }
                   ]

--- a/examples/terraform_files/dc2-spine2.tf
+++ b/examples/terraform_files/dc2-spine2.tf
@@ -39,19 +39,6 @@ resource "terraform-provider-junos-vqfx-evpn-vxlan" "dc2-spine2-base-config" {
                 {
                   grpc = [
                     {
-                      undocumented = [
-                        {
-                          clear_text = [
-                            {
-                              address = "0.0.0.0"
-                              port = 32767
-                            }
-                          ]
-                        },
-                        {
-                          skip_authentication = ""
-                        }
-                      ]
                       max_connections = 30
                     }
                   ]

--- a/junosterraform/jtaf-xml2tf
+++ b/junosterraform/jtaf-xml2tf
@@ -70,13 +70,13 @@ def parse_element(element, explicit_empty_tags, type_lookup, parent_path=""):
     path = f"{parent_path}/{tag_name}" if parent_path and parent_path != tag_name else tag_name
     normalized_path = normalize_tag(path)
 
-    # Check if path is valid in schema
+    # Check if path is valid in schema or not
     if normalized_path not in type_lookup:
-        full_xml_path = path  # non-normalized, user-facing path
-        if full_xml_path not in missing_xpaths:
-            missing_xpaths.add(full_xml_path)
-            # print(f"\t -- [WARN] Unknown XML path not in schema: '{full_xml_path}'\n\t\tAdd this path to an augmented YANG file and re-run yang2go to regenerate the JSON schema.\n\t\tTerraform cannot track this path until it is added.\n", file=sys.stderr)
-            print(f"\t-- [WARN] XML config '{full_xml_path}' not defined in YANG.\n\t\tTo enable configuration of this element, add it to a YANG augment file.\n\t\t - Regenerate the provider using jtaf-yang2go and including this file using the -p option in addition to the existing YANG files.\n", file=sys.stderr)
+        if normalized_path not in missing_xpaths:
+            missing_xpaths.add(normalized_path)
+            print(f"\t-- [WARN] XML config '{missing_xpaths}' not defined in YANG. Removing it from generating in this and subsequent .tf files\n\t\tTo enable configuration of this element, add it to a YANG augment file.\n\t\t - Regenerate the provider using jtaf-yang2go and include the cooresponding yang file using the -p option in addition to the existing YANG files.\n", file=sys.stderr)
+        return None
+        
     # Check if this element should be a leaf-list
     type_info = type_lookup.get(normalized_path, {})
     is_leaf_list = type_info.get("type") == "leaf-list"
@@ -105,6 +105,8 @@ def parse_element(element, explicit_empty_tags, type_lookup, parent_path=""):
     parsed = {}
     for child in element:
         child_data = parse_element(child, explicit_empty_tags, type_lookup, path)
+        if child_data is None:
+            continue
         tag = normalize_tag(child.tag)
 
         # If tag repeats, make sure it’s a flat list
@@ -277,7 +279,10 @@ def parse_xml_to_hcl(xml_file, device_type, hostname, type_lookup):
         base_data = {}
         for elem in root:
             tag = normalize_tag(elem.tag)
-            base_data[tag] = parse_element(elem, explicit_empty_tags, type_lookup)
+            value = parse_element(elem, explicit_empty_tags, type_lookup)
+            if value is None:
+                continue
+            base_data[tag] = value
 
         resources.append(generate_hcl_resources(base_data, device_type, hostname, group_name="base-config", apply_group=True))
 
@@ -287,6 +292,8 @@ def parse_xml_to_hcl(xml_file, device_type, hostname, type_lookup):
             for elem in group_node:
                 tag = normalize_tag(elem.tag)
                 value = parse_element(elem, explicit_empty_tags, type_lookup)
+                if value is None:
+                    continue
                 group_data["groups"][tag] = value
 
             # Determine if group should be applied
@@ -303,10 +310,6 @@ def parse_xml_to_hcl(xml_file, device_type, hostname, type_lookup):
                 # Comment out if group not applied
                 group_resource = '\n'.join([f'# {line}' for line in group_resource.splitlines()])
             resources.append(group_resource)
-
-        for elem in root:
-            tag = normalize_tag(elem.tag)
-            parsed_data[tag] = parse_element(elem, explicit_empty_tags, type_lookup)
 
         return "\n".join(resources)
 
@@ -390,7 +393,7 @@ def main():
                 with open(provider_file, "a") as f:
                     f.write("\n" + head_block)
             else:
-                print(f"\n\tSkipping provider block for hostname '{hostname}' (already exists).\n")
+                print(f"\n  -> Skipping provider block for hostname '{hostname}' (already exists).\n")
 
         # Write per-device .tf file
         hcl_output = parse_xml_to_hcl(file, device_type, hostname, type_lookup)


### PR DESCRIPTION
Editing the example .tf files as well as changing the xml2tf plugin to go BACK to removing from the ,tf rather than just a warning.

This protects pushing config to devices whose version don't accept certain paths.

SSL error should no longer occur